### PR TITLE
feat(getHubberPath): implement Get-HubberPath function to retrieve hubber hierarchy

### DIFF
--- a/public/gethubberpath.ps1
+++ b/public/gethubberpath.ps1
@@ -1,0 +1,23 @@
+function Get-HubberPath{
+    [CmdletBinding()]
+    param (
+        [Parameter(ValueFromPipeline,ValueFromPipelineByPropertyName,Position=0)][string]$Handle
+    )
+
+    $hubber = Get-Hubber -Handle $Handle
+
+    if($null -eq $hubber){
+        throw "Hubber with handle '$Handle' not found"
+    }
+
+    $ret= @()
+    $h = $hubber
+
+    while($h.level -ge 0){
+        $ret += $h
+        $h = $h.manager
+    }
+
+    return $ret
+
+} Export-ModuleMember -Function Get-HubberPath


### PR DESCRIPTION
Introduce a new function to retrieve the hierarchy of a hubber based on the provided handle. This function handles cases where the hubber is not found and constructs the hierarchy by traversing through the manager relationships.